### PR TITLE
Implement and document safe operations on incomplete copies of BS4 elements

### DIFF
--- a/mf2py/dom_helpers.py
+++ b/mf2py/dom_helpers.py
@@ -60,21 +60,21 @@ def get_img_src_alt(img, dict_class, img_with_alt, base_url=''):
 def get_children(node):
     """An iterator over the immediate children tags of this tag"""
     for child in node.children:
-        if isinstance(child, bs4.Tag):
+        if isinstance(child, bs4.Tag) and child.name != 'template':
             yield child
 
 
 def get_descendents(node):
     """An iterator over the all children tags (descendants) of this tag"""
     for desc in node.descendants:
-        if isinstance(desc, bs4.Tag):
+        if isinstance(desc, bs4.Tag) and desc.name != 'template':
             yield desc
 
 def get_textContent(el, replace_img=False, img_to_src=True, base_url=''):
     """ Get the text content of an element, replacing images by alt or src
     """
 
-    DROP_TAGS = ('script', 'style')
+    DROP_TAGS = ('script', 'style',  'template')
     PRE_TAGS = ('pre',)
     P_BREAK_BEFORE = 1
     P_BREAK_AFTER = 0

--- a/mf2py/parser.py
+++ b/mf2py/parser.py
@@ -13,6 +13,7 @@ from .mf_helpers import unordered_list
 import json
 import requests
 import sys
+import copy
 
 if sys.version < '3':
     from urlparse import urlparse, urljoin
@@ -71,6 +72,7 @@ class Parser(object):
     def __init__(self, doc=None, url=None, html_parser=None, img_with_alt=False):
         self.__url__ = None
         self.__doc__ = None
+        self._preserve_doc = False
         self.__parsed__ = self.dict_class([
             ('items', []),
             ('rels', self.dict_class()),
@@ -104,9 +106,10 @@ class Parser(object):
                     doc = data.content
 
         if doc is not None:
-            self.__doc__ = doc
+
             if isinstance(doc, BeautifulSoup) or isinstance(doc, Tag):
                 self.__doc__ = doc
+                self._preserve_doc = True
             else:
                 try:
                     # try the user-given html parser or default html5lib
@@ -140,7 +143,6 @@ class Parser(object):
 
         if self.__doc__ is not None:
             # parse!
-            temp_fixes.apply_rules(self.__doc__)
             self.parse()
 
     def parse(self):
@@ -332,9 +334,13 @@ class Parser(object):
                 if e_value is None:
                     # send original element for parsing backcompat
                     if el.original is None:
-                        e_value = parse_property.embedded(el, base_url=self.__url__)
+                        embedded_el = el
                     else:
-                        e_value = parse_property.embedded(el.original, base_url=self.__url__)
+                        embedded_el = el.original
+                    if self._preserve_doc:
+                        embedded_el = copy.copy(embedded_el)
+                    temp_fixes.rm_templates(embedded_el)
+                    e_value = parse_property.embedded(embedded_el, base_url=self.__url__)
 
                 if root_class_names:
                     stops_implied_name = True

--- a/mf2py/temp_fixes.py
+++ b/mf2py/temp_fixes.py
@@ -1,7 +1,3 @@
-from .dom_helpers import get_descendents
-
-
-def apply_rules(doc):
-    for el in get_descendents(doc):
-        if el.name == 'template':
-            el.extract()
+def rm_templates(doc):
+    for el in doc.find_all('template'):
+        el.extract()

--- a/test/examples/template_tag_inside_e_value.html
+++ b/test/examples/template_tag_inside_e_value.html
@@ -1,0 +1,11 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<title>Template tag test</title>
+</head>
+<body>
+<div class="h-entry">
+    <div class="e-content">This is a Test with a <code>template</code> tag after this:<template>This should <b>never</b> be in the output</template></div>
+</div>
+</body>
+</html>

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -261,6 +261,13 @@ def test_template_parse():
     result = parse_fixture("template_tag.html")
     assert_equal(0, len(result["items"]))
 
+def test_template_tag_inside_e_value():
+    result = parse_fixture("template_tag_inside_e_value.html")
+    assert_equal("This is a Test with a <code>template</code> tag after this:",
+                 result['items'][0]['properties']['content'][0]['html'])
+    assert_equal("This is a Test with a template tag after this:",
+                 result['items'][0]['properties']['content'][0]['value'])
+
 def test_ordering_dedup():
     ''' test that classes are dedeuped and alphabetically ordered '''
 

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -877,3 +877,20 @@ def test_unicode_everywhere():
         result = parse_fixture(h)
         yield check_unicode, h, result
 
+
+def test_input_tree_integrity():
+    """ make sure that if we parse a BS4 soup, our modifications do not leak into the document represented by it """
+
+    for path in get_all_files():
+        with open(os.path.join(TEST_DIR, path)) as f:
+            soup = BeautifulSoup(f,features='lxml')
+            html1 = soup.prettify()
+            p = Parser(doc=soup, html_parser='lxml')
+            html2 = soup.prettify()
+        yield make_labelled_cmp("tree_integrity_" + path), html1, html2
+
+
+def make_labelled_cmp(label):
+    f = lambda html1, html2: assert_equal(html1,html2)
+    f.description = label
+    return f


### PR DESCRIPTION
This modifies the modifying parts of backcompat.py to only affect the copied Tags, not the original ones, and I added a comment with some hints on what to do safely.

This still needs test ensuring it works: I'm thinking of changing all backcompat tests to create their own BS soups and additionally checking it for changes afterwards?